### PR TITLE
Removes action from user edit form

### DIFF
--- a/glider_dac/views/user.py
+++ b/glider_dac/views/user.py
@@ -30,7 +30,6 @@ class UserForm(Form):
 def edit_user(username):
     app.logger.info("GET %s", username)
     app.logger.info("Request URL: %s", request.url)
-    action_path = request.url
     user = db.User.find_one({'username': username})
     if user is None or (user is not None and not current_user.is_admin() and current_user != user):
         # No permission
@@ -51,7 +50,7 @@ def edit_user(username):
         flash("Account updated", 'success')
         return redirect(url_for("index"))
 
-    return render_template('edit_user.html', form=form, user=user, action_path=action_path)
+    return render_template('edit_user.html', form=form, user=user)
 
 
 @app.route('/admin', methods=['GET', 'POST'])


### PR DESCRIPTION
Removes action from user edit form, causing the form to render action
attribute as "".  This fixes some http redirection issues in #104, but
ultimately, a way to always use https:// scheme on the production
settings should eventually be found.