### PR TITLE
Use passlib to encrypt passwords with SHA512

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Flask-Script==2.0.5
 feedparser==5.1.3
 sh==1.09
 requests==2.4.3
+passlib>=1.7.1
 -e git://github.com/asascience-open/thredds_crawler@c2164e3a805e423ff06e52986a8753038e9c00ce#egg=thredds_crawler-master
 Flask-KVSession==0.6.2
 Flask-Environments==0.1


### PR DESCRIPTION
Uses passlib's SHA512 encryption to encrypt/verify passwords stored
in BerkeleyDB, rather than storing them in plaintext, which is a security risk.

Important note:  If using pam_userdb as an auth provider to vsftpd, ensure
the following lines are present in the PAM configuration for vsftpd,
where <USER_DB_LOC> is the location of the BerkeleyDB user database:

auth    required    pam_userdb.so db=<USER_DB_LOC> crypt=crypt
account required    pam_userdb.so db=<USER_DB_LOC> crypt=crypt
session required    pam_loginuid.so