### PR TITLE
Add upload raw data button. Create endpoint to initiate request to up…

### DIFF
--- a/glider_dac/templates/show_deployment.html
+++ b/glider_dac/templates/show_deployment.html
@@ -36,6 +36,14 @@
     </div>
   </div>
 
+  <div>
+    <hr />
+    <p style="text-align: left"><b>OR</b></p>
+    <button type="button" class="btn btn-default" id="upload-raw-button">
+      Upload Raw File
+    </button>
+  </div>
+
   <script type="text/javascript">
     $(function() {
       var drop = $('#dropbox');
@@ -134,6 +142,45 @@
 
       });
     });
+
+    $(function() {
+      var gliderUploadUrl = 'http://localhost:3001/' // 'https://www.google.com/';
+      $('#upload-raw-button').on('click', function() {
+        var url = "{{ url_for('upload_raw_deployment_files', username=username, deployment_id=deployment._id) }}";
+        var req = $.ajax({
+            type: 'GET',
+            url: url,
+            contentType: 'application/json;charset=UTF-8',
+          });
+
+          req.done(function(resp) {
+            // save pertinent info in both a cookie and localStorage since I don't know how gliderdac and 
+            // gliderdac upload will be integrated
+
+            // TODO: put this in a loop to simplify
+            var expirationTime = moment().utc().add(5,'m').format('ddd, D MMM YYYY HH:mm:ss UTC');
+            document.cookie = `name=${resp['name']}; expires=${expirationTime}; path=/`;
+            document.cookie = `token=${resp['token']}; expires=${expirationTime}; path=/`;
+            document.cookie = `email=${resp['email']}; expires=${expirationTime}; path=/`;
+            document.cookie = `organization=${resp['organization']}; expires=${expirationTime}; path=/`;
+            
+            // local storage isnt updating when domain is the same (hence save in cookie as well)
+            if (typeof(Storage) !== "undefined") {
+              for (key in resp) {
+                localStorage.setItem([key], resp[key]);
+              }
+              window.open(gliderUploadUrl, '_blank');
+              // setTimeout(function() {localStorage.clear()}, 10000); // clear local storage after 10 seconds
+            } else {
+              alert('Sorry a problem was encountered with your browser');
+            }
+          });
+
+          req.fail(function(jqxhr, textStatus, error) {
+            // do stuff
+          });
+      })
+    })
 
     $(function() {
 


### PR DESCRIPTION
…load backend for JWT token. Save token and other parameters in cookies/localStorage for use in authenticating user in gliderdac-upload app.

@Bobfrat this isn't ready to be merged. Its the start of the workflow though to connect the upload tool with this app. It's a point of reference when you start working on the user validation endpoint when the upload tool verifies that a user is logged in before returning a JWT. In addition to username, email, organization, and token what else do we need to pass between this app and the upload tool? (i.e. deployment name, deployment id, glider name, .... )