### PR TITLE
Temporarily stop delayed mode processing

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -175,7 +175,8 @@ def build_erddap_catalog_fragment(data_root, user, deployment, template_dir,
                            completed=completed,
                            reqd_qc_vars=required_qc_vars,
                            dest_var_remaps=dest_var_remaps,
-                           qc_var_types=qc_var_types)
+                           qc_var_types=qc_var_types,
+                           delayed_mode=delayed_mode)
     if not extra_atts and not standard_name_vars:
         return templ
 

--- a/scripts/glider_qartod.py
+++ b/scripts/glider_qartod.py
@@ -122,6 +122,8 @@ def get_files(netcdf_files):
     '''
     file_paths = []
     for netcdf_dir in netcdf_files:
+        if netcdf_dir.endswith("-delayed"):
+            continue
         for (path, dirs, files) in os.walk(netcdf_dir):
             for filename in files:
                 if filename.endswith('.nc'):

--- a/scripts/replicatePrivateErddapDeployments.py
+++ b/scripts/replicatePrivateErddapDeployments.py
@@ -113,12 +113,15 @@ def main(args):
 
         log.info( "Processing the following deployments")
         for deployment in deployments:
-            log.info( " - %s", deployment)
+            if not deployment.endswith("-delayed"):
+                log.info( " - %s", deployment)
         # limit to 8 simultaneous connections open for fetching data
-        sem = asyncio.Semaphore(8)
+        # badams (2020-07-30) limit to two concurrent processes to avoid bogging down server
+        sem = asyncio.Semaphore(2)
         loop = asyncio.get_event_loop()
         tasks = [loop.create_task(sync_deployment(d, sem, args.force))
-                                                  for d in deployments]
+                                                  for d in deployments
+                                                  if not d.endswith("-delayed")]
         wait_tasks = asyncio.wait(tasks)
         loop.run_until_complete(wait_tasks)
         loop.close()


### PR DESCRIPTION
Stops delayed mode dataset replication and QC.  Adds delayed mode
attribute to glider template.  Reduces async semaphore count for
replication from 8 to 2.