### PR TITLE
Properly handle delayed mode before passing to templates

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -95,6 +95,7 @@ def build_erddap_catalog_fragment(data_root, user, deployment, template_dir,
             wmo_id          = wmo_id.strip()
             checksum        = js.get('checksum', '').strip()
             completed       = js['completed']
+            delayed_mode    = js.get("delayed_mode", False)
     except (OSError, IOError, AssertionError, AttributeError) as e:
         print(("%s: %s" % (repr(e), e.message)))
         print(e)


### PR DESCRIPTION
Fixes problems passing delayed mode status to templates (curently unused, but may be useful in future iterations)