### PR TITLE
Fixes error with datasets snippet where str expected

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -216,7 +216,7 @@ def build_erddap_catalog_fragment(data_root, user, deployment, template_dir,
                             else:
                                 continue
 
-                return etree.tostring(tree)
+                return etree.tostring(tree, encoding=str)
 
             except:
                 logger.exception("Exception occurred while generating dataset XML:")


### PR DESCRIPTION
Fixes an issue under Python 3 where a file expected string/unicode to be
written, but fails because etree.tostring returns bytes by default.
Updated code adds the encoding argument to etree.tostring, fixing this
issue.