### PR TITLE
Fix bug in get_mod_time logic

### DIFF
--- a/scripts/replicatePrivateErddapDeployments.py
+++ b/scripts/replicatePrivateErddapDeployments.py
@@ -4,7 +4,6 @@ import argparse
 import async_timeout
 import asyncio
 import calendar
-import datetime
 import glob
 import json
 import logging
@@ -190,10 +189,11 @@ def get_mod_time(name):
 
     try:
         newest = max(glob.iglob(JSON_DIR + name + '/' + '*.nc') , key=os.path.getmtime)
+        ncTime = os.path.getmtime(newest)
     # if there are no nc files, arbitrarily set time as 0
     except ValueError:
-        newest = 0
-    ncTime = os.path.getmtime(newest)
+        ncTime = 0
+
     if not os.path.exists(jsonFile):
         log.info( "JSON file does not exist.")
         with open(jsonFile, 'w') as outfile:

--- a/scripts/sync_erddap_datasets.py
+++ b/scripts/sync_erddap_datasets.py
@@ -4,7 +4,6 @@ import argparse
 import async_timeout
 import asyncio
 import calendar
-import datetime
 import glob
 import json
 import logging
@@ -159,10 +158,10 @@ def get_mod_time(name):
 
     try:
         newest = max(glob.iglob(JSON_DIR + name + '/' + '*.nc') , key=os.path.getmtime)
+        ncTime = os.path.getmtime(newest)
     except ValueError:
         # if there are no nc files, arbitrarily set time as 0
-        newest = 0
-    ncTime = os.path.getmtime(newest)
+        ncTime = 0
     if not os.path.exists(jsonFile):
         with open(jsonFile, 'w') as outfile:
             json.dump({'updated': ncTime * 1000}, outfile)


### PR DESCRIPTION
@benjwadams turns out `os.path.getmtime(0)` returns the current time in python 3. Better than an exception but not what we're looking for here. Basically we end up asking ERDDAP to update deployments with no files.

The removing of `import datetime` is because we use `from datetime import datetime` below that.