### PR TITLE
Hotfix for Py3 slugify method

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -374,7 +374,9 @@ def slugify(value):
     import unicodedata
     import re
     value = str(value)
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    # BWA: this appears to break the code under Py3 in the re.sub due to
+    # casting to bytes rather than str
+    #value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
     value = str(re.sub('[^\w\s-]', '', value).strip())
     return str(re.sub('[-\s]+', '-', value))
 


### PR DESCRIPTION
Fixes a unicode issue with slugify method under Py3 where a string was cast
to bytes.