### PR TITLE
Create deployment if mode differs but callsign/date is same

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       - 3000:5000
     volumes:
       - ./config.local.yml:/glider-dac/config.local.yml
-      # - .:/glider-dac/  # For local development
+    #  # - .:/glider-dac/  # For local development
+      - ./users.db:/glider-dac/users.db
+
     depends_on:
       - mongo
       - redis


### PR DESCRIPTION
Will create glider deployments with same glider identifier (e.g. "ru30"), and time, but differing delayed mode vs real time settings. Thus, the following scenarios will work:

- Real-time dataset exists and marked as completed, delayed mode creation
(same as marking existing deployment as delayed mode)
- Delayed mode dataset exists and marked as completed, real-time creation
- Same mode for both existing dataset and desired created deployment
  will fail, since the unique deployment name already exists
- Delayed or real-time mode with no pre-existing deployments will create
  deployments as usual.