### PR TITLE
Use deployment name instead of ID for detail view

### DIFF
--- a/glider_dac/templates/index.html
+++ b/glider_dac/templates/index.html
@@ -18,7 +18,7 @@
       <tbody>
       {%- for m in deployments %}
       <tr>
-        <td class="col-lg-4"><a href="{{ url_for('show_deployment_no_username', deployment_id=m._id) }}">{{ m.name }}</a></td>
+        <td class="col-lg-4"><a href="{{ url_for('show_deployment', deployment_name=m.name) }}">{{ m.name }}</a></td>
         <td class="col-lg-4">{{ m.wmo_id }}</td>
         <td class="col-lg-4"><abbr title="{{ m.created | datetimeformat }} UTC">{{ m.created | prettydate }}</abbr></td>
       </tr>

--- a/glider_dac/templates/user_deployments.html
+++ b/glider_dac/templates/user_deployments.html
@@ -59,7 +59,7 @@ $(function() {
     <tbody>
     {%- for m in deployments %}
     <tr>
-      <td><a href="{{ url_for('show_deployment', username=username, deployment_id=m._id) }}">{{ m.name }}</a></td>
+      <td><a href="{{ url_for('show_deployment', username=username, deployment_id=m.name) }}">{{ m.name }}</a></td>
       <td>{% if m.operator %}<a href="{{ url_for('list_operator_deployments', operator=m.operator) }}">{{ m.operator }}{% endif %}</a></td>
       <td data-value="{{ m.updated }}"><abbr title="{{ m.updated | datetimeformat }} UTC">{{ m.updated | prettydate }}</abbr></td>
       <td>


### PR DESCRIPTION
Uses /deployment/<deployment_name> instead of variants of /users/<username>/deployment/<deployment_id> for referencing glider deployments since the former serves as a unique key already and is easier to memorize than a MongoDB/BSON ObjectID.  Currently breaking change/backwards incompatible with old scheme, but fixes #209.