### PR TITLE
Add WMO ID display to glider deployment detail page

### DIFF
--- a/glider_dac/templates/show_deployment.html
+++ b/glider_dac/templates/show_deployment.html
@@ -230,6 +230,8 @@
 
   {% endif %}
 
+  <h3>Assigned WMO ID</h3>
+    <p>{{ deployment.wmo_id }}</p>
   <h3>Compliance Check Report</h3>
   {% set report_passed = deployment.compliance_check_passed %}
   {% if report_passed is undefined %}
@@ -238,7 +240,7 @@
     {% set standard_name_errors = [] %}
     {% for err in deployment.compliance_check_report.high_priorities %}
        {% if err.name == "Standard Names" %}
-       {# Hack.  Move to models or elsewher if logic becomes more complicated #}
+       {# Hack.  Move to models or elsewhere if logic becomes more complicated #}
        {{ standard_name_errors.extend(err["msgs"]) or "" }}
        {% endif %}
     {% endfor %}


### PR DESCRIPTION
Improves situation for #349 by adding WMO IDs to page detail.