### PR TITLE
Exclude QARTOD variables not provided by user for delayed mode datasets.xml

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -570,16 +570,19 @@ def build_erddap_catalog_chunk(data_root, deployment):
 
         qartod_var_type = check_for_qartod_vars(ds)
 
-        exclude_vars = (existing_varnames |
-                        {'latitude', 'longitude'} |
-                        qartod_var_type['qartod'].keys())
+        exclude_vars = (existing_varnames | {'latitude', 'longitude'})
 
         all_other_vars = [add_erddap_var_elem(var) for var in
                           ds.get_variables_by_attributes(name=lambda n: n not in exclude_vars)]
 
         gts_ingest = getattr(ds, 'gts_ingest', 'true')  # Set default value to true
 
-        qartod_vars_snippet = qartod_var_snippets(required_qartod_vars, qartod_var_type)
+        # Exclude automatic QARTOD variables if the dataset is delayed mode
+        # This will keep any user supplied QARTOD variables, they should be part of
+        # `all_other_vars` already
+        qartod_vars_snippet = (qartod_var_snippets(required_qartod_vars,
+                                                   qartod_var_type)
+                               if not deployment.delayed_mode else [])
 
         vars_sorted = sorted(common_variables +
                              qartod_vars_snippet + all_other_vars,


### PR DESCRIPTION
More or less preserves existing QARTOD behavior for existing real-time data -- keeps these variables if they exist, but now uses some logic to keep those attributes.  Automatic QC variable creation and associated QARTOD variables will still be kept where QARTOD is not provided.

For delayed mode, only include QARTOD variables if they exist for within the datasets.

cc: @kerfoot