### PR TITLE
Hard-code the QARTOD variables' standard and long names in the .xml f…

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -677,7 +677,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
 
         try:
             tree = etree.fromstring(rf"""
-                    <dataset type="EDDTableFromNcFiles" datasetID={deployment.name} active="true">
+                    <dataset type="EDDTableFromNcFiles" datasetID="{deployment.name}" active="true">
                         <!-- defaultDataQuery uses datasetID -->
                         <!--
                         <defaultDataQuery>&amp;trajectory={deployment.name}</defaultDataQuery>

--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -529,43 +529,122 @@ def build_erddap_catalog_chunk(data_root, deployment):
     """).findall("dataVariable")
 
 
-
-    required_qartod_vars = {"qartod_conductivity_flat_line_flag",
-                            "qartod_conductivity_gross_range_flag",
-                            "qartod_conductivity_primary_flag",
-                            "qartod_conductivity_rate_of_change_flag",
-                            "qartod_conductivity_spike_flag",
-                            "qartod_density_flat_line_flag",
-                            "qartod_density_gross_range_flag",
-                            "qartod_density_primary_flag",
-                            "qartod_density_rate_of_change_flag",
-                            "qartod_density_spike_flag",
-                            "qartod_monotonic_pressure_flag",
-                            "qartod_pressure_flat_line_flag",
-                            "qartod_pressure_gross_range_flag",
-                            "qartod_pressure_primary_flag",
-                            "qartod_pressure_rate_of_change_flag",
-                            "qartod_pressure_spike_flag",
-                            "qartod_salinity_flat_line_flag",
-                            "qartod_salinity_gross_range_flag",
-                            "qartod_salinity_primary_flag",
-                            "qartod_salinity_rate_of_change_flag",
-                            "qartod_salinity_spike_flag",
-                            "qartod_temperature_flat_line_flag",
-                            "qartod_temperature_gross_range_flag",
-                            "qartod_temperature_primary_flag",
-                            "qartod_temperature_rate_of_change_flag",
-                            "qartod_temperature_spike_flag"}
-
-
-    existing_varnames = {'trajectory', 'wmo_id', 'profile_id', 'profile_time',
-                         'profile_lat', 'profile_lon', 'time', 'depth',
-                         'pressure', 'temperature', 'conductivity', 'salinity',
-                         'density', 'lat', 'lon', 'time_uv', 'lat_uv',
-                         'lon_uv', 'u', 'v', 'platform', 'instrument_ctd'}
+    required_qartod_vars = {
+            'qartod_conductivity_flat_line_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_electrical_conductivity',
+                'standard_name': 'flat_line_test_quality_flag',
+            },
+            'qartod_conductivity_gross_range_flag': {
+                'long_name': 'QARTOD Gross Range Test for sea_water_electrical_conductivity',
+                'standard_name': 'gross_range_test_quality_flag',
+            },
+            'qartod_conductivity_rate_of_change_flag': {
+                'long_name': 'QARTOD Rate of Change Test for sea_water_electrical_conductivity',
+                'standard_name': 'rate_of_change_test_quality_flag'
+            },
+            'qartod_conductivity_spike_flag': {
+                'long_name': 'QARTOD Spike Test for sea_water_electrical_conductivity',
+                'standard_name': 'spike_test_quality_flag',
+            },
+            'qartod_conductivity_primary_flag': {
+                'long_name': 'QARTOD Primary Flag for sea_water_electrical_conductivity',
+                'standard_name': 'aggregate_quality_flag'
+            },
+            'qartod_density_flat_line_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_density ',
+                'standard_name': 'flat_line_test_quality_flag'   
+            },
+            'qartod_density_gross_range_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_density ',
+                'standard_name': 'gross_range_test_quality_flag'   
+            },
+            'qartod_density_primary_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_density ',
+                'standard_name': 'aggregate_quality_flag' 
+            },
+            'qartod_density_rate_of_change_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_density ',
+                'standard_name': 'rate_of_change_test_quality_flag'  
+            },
+            'qartod_density_spike_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_density',
+                'standard_name': 'spike_test_quality_flag'  
+            },
+            'qartod_pressure_flat_line_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
+                'standard_name': 'flat_line_test_quality_flag' 
+            },
+            'qartod_pressure_gross_range_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
+                'standard_name': 'gross_range_test_quality_flag'  
+            },
+            'qartod_pressure_primary_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
+                'standard_name': 'aggregate_quality_flag' 
+            },
+            'qartod_pressure_rate_of_change_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
+                'standard_name': 'rate_of_change_test_quality_flag'   
+            },
+            'qartod_pressure_spike_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
+                'standard_name': 'spike_test_quality_flag' 
+            },
+            'qartod_salinity_flat_line_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
+                'standard_name': 'flat_line_test_quality_flag'  
+            },
+            'qartod_salinity_gross_range_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
+                'standard_name': 'gross_range_test_quality_flag' 
+            },
+            'qartod_salinity_primary_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
+                'standard_name': 'aggregate_quality_flag' 
+            },
+            'qartod_salinity_rate_of_change_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
+                'standard_name': 'rate_of_change_test_quality_flag'  
+            },
+            'qartod_salinity_spike_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
+                'standard_name': 'spike_test_quality_flag' 
+            },
+            'qartod_temperature_flat_line_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
+                'standard_name': 'flat_line_test_quality_flag'  
+            },
+            'qartod_temperature_gross_range_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
+                'standard_name': 'gross_range_test_quality_flag'  
+            },
+            'qartod_temperature_primary_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
+                'standard_name':  'aggregate_quality_flag' 
+            },
+            'qartod_temperature_rate_of_change_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
+                'standard_name': 'rate_of_change_test_quality_flag'   
+            },
+            'qartod_temperature_spike_flag': {
+                'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
+                'standard_name': 'spike_test_quality_flag'  
+            },
+            'qartod_location_flag': {
+                'long_name': 'QARTOD Location Test for longitude and latitude',
+                'standard_name': 'location_test_quality_flag' 
+            },
+        }
+    
+    existing_varnames = {'trajectory', 'wmo_id', 'platform', 'instrument_ctd
+                         'profile_id', 'profile_time', 'profile_lat', 'profile_lon',
+                         'time', 'depth', 'lat', 'lon',
+                         'pressure', 'temperature', 'conductivity', 'salinity', 'density',
+                         'time_uv', 'lat_uv', 'lon_uv', 'u', 'v''}
 
 
     nc_file = os.path.join(data_root, deployment_dir, latest_file)
+    
     with Dataset(nc_file, 'r') as ds:
 
         qartod_var_type = check_for_qartod_vars(ds)
@@ -649,36 +728,41 @@ def build_erddap_catalog_chunk(data_root, deployment):
 def qartod_var_snippets(required_qartod_vars, qartod_var_type):
 
     var_list = []
-    for req_var in required_qartod_vars:
-        # If the required QARTOD QC variable isn't already defined,
+    for req_var, template in list(required_qartod_vars.items()):
+        
+        # If the required QARTOD variable isn't already defined,
         # then supply a set of default attributes.
-
+       
         if req_var in qartod_var_type['qartod']:
             continue
 
         else:
 
             flag_atts = """
-                  <att name="ioos_category">Quality</att>
-                  <att name="flag_values" type="byteList">1 2 3 4 9</att>
-                  <att name="flag_meanings">PASS NOT_EVALUATED SUSPECT FAIL MISSING</att>
-                  <att name="valid_min" type="byte">1</att>
-                  <att name="valid_max" type="byte">9</att>
-                  <att name="dac_comment">ioos_qc_module_qartod</att>
-                  <att name="https://gliders.ioos.us/files/Manual-for-QC-of-Glider-Data_05_09_16.pdf"></att>
-                  """
-
+                    <att name="_FillValue" type="byte">2</att>
+                    <att name="dac_comment">QARTOD TESTS NOT RUN</att>
+                    <att name="flag_values" type="byteList">1 2 3 4 9</att>
+                    <att name="flag_meanings">PASS NOT_EVALUATED SUSPECT FAIL MISSING</att>
+                    <att name="ioos_category">Quality</att>
+                    <att name="references">https://gliders.ioos.us/files/Manual-for-QC-of-Glider-Data_05_09_16.pdf</att>
+                    <att name="units">1</att>
+                    <att name="valid_min" type="byte">1</att>
+                    <att name="valid_max" type="byte">9</att>
+                    """
+     
         qartod_snip = f"""
             <dataVariable>
-               <sourceName>{req_var}</sourceName>
-               <destinationName>{req_var}</destinationName>
-               <dataType>byte</dataType>
-               <addAttributes>
-                  {flag_atts}
-               </addAttributes>
+                <sourceName>{req_var}</sourceName>
+                <destinationName>{req_var}</destinationName>
+                <dataType>byte</dataType>
+                <addAttributes> 
+                    <att name="long_name">{template['long_name']}</att>
+                    <att name="standard_name"> {template['standard_name']} </att>
+                    {flag_atts}
+                </addAttributes>
             </dataVariable>
             """
-
+        
         var_list.append(etree.fromstring(qartod_snip))
 
     return var_list

--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -528,15 +528,14 @@ def build_erddap_catalog_chunk(data_root, deployment):
     </test>
     """).findall("dataVariable")
 
-
     required_qartod_vars = {
             'qartod_conductivity_flat_line_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_electrical_conductivity',
-                'standard_name': 'flat_line_test_quality_flag',
+                'standard_name': 'flat_line_test_quality_flag'
             },
             'qartod_conductivity_gross_range_flag': {
                 'long_name': 'QARTOD Gross Range Test for sea_water_electrical_conductivity',
-                'standard_name': 'gross_range_test_quality_flag',
+                'standard_name': 'gross_range_test_quality_flag'
             },
             'qartod_conductivity_rate_of_change_flag': {
                 'long_name': 'QARTOD Rate of Change Test for sea_water_electrical_conductivity',
@@ -544,7 +543,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
             },
             'qartod_conductivity_spike_flag': {
                 'long_name': 'QARTOD Spike Test for sea_water_electrical_conductivity',
-                'standard_name': 'spike_test_quality_flag',
+                'standard_name': 'spike_test_quality_flag'
             },
             'qartod_conductivity_primary_flag': {
                 'long_name': 'QARTOD Primary Flag for sea_water_electrical_conductivity',
@@ -552,95 +551,95 @@ def build_erddap_catalog_chunk(data_root, deployment):
             },
             'qartod_density_flat_line_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_density ',
-                'standard_name': 'flat_line_test_quality_flag'   
+                'standard_name': 'flat_line_test_quality_flag'
             },
             'qartod_density_gross_range_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_density ',
-                'standard_name': 'gross_range_test_quality_flag'   
+                'standard_name': 'gross_range_test_quality_flag'
             },
             'qartod_density_primary_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_density ',
-                'standard_name': 'aggregate_quality_flag' 
+                'standard_name': 'aggregate_quality_flag'
             },
             'qartod_density_rate_of_change_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_density ',
-                'standard_name': 'rate_of_change_test_quality_flag'  
+                'standard_name': 'rate_of_change_test_quality_flag'
             },
             'qartod_density_spike_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_density',
-                'standard_name': 'spike_test_quality_flag'  
+                'standard_name': 'spike_test_quality_flag'
             },
             'qartod_pressure_flat_line_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
-                'standard_name': 'flat_line_test_quality_flag' 
+                'standard_name': 'flat_line_test_quality_flag'
             },
             'qartod_pressure_gross_range_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
-                'standard_name': 'gross_range_test_quality_flag'  
+                'standard_name': 'gross_range_test_quality_flag'
             },
             'qartod_pressure_primary_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
-                'standard_name': 'aggregate_quality_flag' 
+                'standard_name': 'aggregate_quality_flag'
             },
             'qartod_pressure_rate_of_change_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
-                'standard_name': 'rate_of_change_test_quality_flag'   
+                'standard_name': 'rate_of_change_test_quality_flag'
             },
             'qartod_pressure_spike_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_pressure',
-                'standard_name': 'spike_test_quality_flag' 
+                'standard_name': 'spike_test_quality_flag'
             },
             'qartod_salinity_flat_line_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
-                'standard_name': 'flat_line_test_quality_flag'  
+                'standard_name': 'flat_line_test_quality_flag'
             },
             'qartod_salinity_gross_range_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
-                'standard_name': 'gross_range_test_quality_flag' 
+                'standard_name': 'gross_range_test_quality_flag'
             },
             'qartod_salinity_primary_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
-                'standard_name': 'aggregate_quality_flag' 
+                'standard_name': 'aggregate_quality_flag'
             },
             'qartod_salinity_rate_of_change_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
-                'standard_name': 'rate_of_change_test_quality_flag'  
+                'standard_name': 'rate_of_change_test_quality_flag'
             },
             'qartod_salinity_spike_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_practical_salinity',
-                'standard_name': 'spike_test_quality_flag' 
+                'standard_name': 'spike_test_quality_flag'
             },
             'qartod_temperature_flat_line_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
-                'standard_name': 'flat_line_test_quality_flag'  
+                'standard_name': 'flat_line_test_quality_flag'
             },
             'qartod_temperature_gross_range_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
-                'standard_name': 'gross_range_test_quality_flag'  
+                'standard_name': 'gross_range_test_quality_flag'
             },
             'qartod_temperature_primary_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
-                'standard_name':  'aggregate_quality_flag' 
+                'standard_name':  'aggregate_quality_flag'
             },
             'qartod_temperature_rate_of_change_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
-                'standard_name': 'rate_of_change_test_quality_flag'   
+                'standard_name': 'rate_of_change_test_quality_flag'
             },
             'qartod_temperature_spike_flag': {
                 'long_name': 'QARTOD Flat Line Test for sea_water_temperature',
-                'standard_name': 'spike_test_quality_flag'  
+                'standard_name': 'spike_test_quality_flag'
             },
             'qartod_location_flag': {
                 'long_name': 'QARTOD Location Test for longitude and latitude',
-                'standard_name': 'location_test_quality_flag' 
+                'standard_name': 'location_test_quality_flag'
             },
         }
     
-    existing_varnames = {'trajectory', 'wmo_id', 'platform', 'instrument_ctd
+    existing_varnames = {'trajectory', 'wmo_id', 'platform', 'instrument_ctd',
                          'profile_id', 'profile_time', 'profile_lat', 'profile_lon',
                          'time', 'depth', 'lat', 'lon',
                          'pressure', 'temperature', 'conductivity', 'salinity', 'density',
-                         'time_uv', 'lat_uv', 'lon_uv', 'u', 'v''}
+                         'time_uv', 'lat_uv', 'lon_uv', 'u', 'v'}
 
 
     nc_file = os.path.join(data_root, deployment_dir, latest_file)
@@ -678,44 +677,44 @@ def build_erddap_catalog_chunk(data_root, deployment):
 
         try:
             tree = etree.fromstring(rf"""
-                <dataset type="EDDTableFromNcFiles" datasetID="{deployment.name}" active="true">
-                    <!-- defaultDataQuery uses datasetID -->
-                    <!--
-                    <defaultDataQuery>&amp;trajectory={deployment.name}</defaultDataQuery>
-                    <defaultGraphQuery>longitude,latitude,time&amp;.draw=markers&amp;.marker=2|5&.color=0xFFFFFF&.colorBar=|||||</defaultGraphQuery>
-                    -->
-                    {reload_settings}
-                    <updateEveryNMillis>-1</updateEveryNMillis>
-                    <!-- use datasetID as the directory name -->
-                    <fileDir>{dir_path}</fileDir>
-                    <recursive>false</recursive>
-                    <fileNameRegex>.*\.nc</fileNameRegex>
-                    <metadataFrom>last</metadataFrom>
-                    <sortedColumnSourceName>time</sortedColumnSourceName>
-                    <sortFilesBySourceNames>trajectory time</sortFilesBySourceNames>
-                    <fileTableInMemory>false</fileTableInMemory>
-                    <accessibleViaFiles>true</accessibleViaFiles>
-                    <addAttributes>
-                        <att name="cdm_data_type">trajectoryProfile</att>
-                        <att name="featureType">trajectoryProfile</att>
-                        <att name="cdm_trajectory_variables">trajectory,wmo_id</att>
-                        <att name="cdm_profile_variables">time_uv,lat_uv,lon_uv,u,v,profile_id,time,latitude,longitude</att>
-                        <att name="subsetVariables">wmo_id,trajectory,profile_id,time,latitude,longitude</att>
-
-                        <att name="Conventions">Unidata Dataset Discovery v1.0, COARDS, CF-1.6</att>
-                        <att name="keywords">AUVS > Autonomous Underwater Vehicles, Oceans > Ocean Pressure > Water Pressure, Oceans > Ocean Temperature > Water Temperature, Oceans > Salinity/Density > Conductivity, Oceans > Salinity/Density > Density, Oceans > Salinity/Density > Salinity, glider, In Situ Ocean-based platforms > Seaglider, Spray, Slocum, trajectory, underwater glider, water, wmo</att>
-                        <att name="keywords_vocabulary">GCMD Science Keywords</att>
-                        <att name="Metadata_Conventions">Unidata Dataset Discovery v1.0, COARDS, CF-1.6</att>
-                        <att name="sourceUrl">(local files)</att>
-                        <att name="infoUrl">https://gliders.ioos.us/erddap/</att>
-                        <!-- title=datasetID -->
-                        <att name="title">{deployment.name}</att>
-                        <att name="ioos_dac_checksum">{checksum}</att>
-                        <att name="ioos_dac_completed">{completed}</att>
-                        <att name="gts_ingest">{gts_ingest}</att>
-                     </addAttributes>
-                </dataset>
+                    <dataset type="EDDTableFromNcFiles" datasetID={deployment.name} active="true">
+                        <!-- defaultDataQuery uses datasetID -->
+                        <!--
+                        <defaultDataQuery>&amp;trajectory={deployment.name}</defaultDataQuery>
+                        <defaultGraphQuery>longitude,latitude,time&amp;.draw=markers&amp;.marker=2|5&.color=0xFFFFFF&.colorBar=|||||</defaultGraphQuery>
+                        -->
+                        {reload_settings}
+                        <updateEveryNMillis>-1</updateEveryNMillis>
+                        <!-- use datasetID as the directory name -->
+                        <fileDir>{dir_path}</fileDir>
+                        <recursive>false</recursive>
+                        <fileNameRegex>.*\.nc</fileNameRegex>
+                        <metadataFrom>last</metadataFrom>
+                        <sortedColumnSourceName>time</sortedColumnSourceName>
+                        <sortFilesBySourceNames>trajectory time</sortFilesBySourceNames>
+                        <fileTableInMemory>false</fileTableInMemory>
+                        <accessibleViaFiles>true</accessibleViaFiles>
+                        <addAttributes>
+                            <att name="cdm_data_type">trajectoryProfile</att>
+                            <att name="featureType">trajectoryProfile</att>
+                            <att name="cdm_trajectory_variables">trajectory,wmo_id</att>
+                            <att name="cdm_profile_variables">time_uv,lat_uv,lon_uv,u,v,profile_id,time,latitude,longitude</att>
+                            <att name="subsetVariables">wmo_id,trajectory,profile_id,time,latitude,longitude</att>
+                            <att name="Conventions">Unidata Dataset Discovery v1.0, COARDS, CF-1.6</att>
+                            <att name="keywords">AUVS > Autonomous Underwater Vehicles, Oceans > Ocean Pressure > Water Pressure, Oceans > Ocean Temperature > Water Temperature, Oceans > Salinity/Density > Conductivity, Oceans > Salinity/Density > Density, Oceans > Salinity/Density > Salinity, glider, In Situ Ocean-based platforms > Seaglider, Spray, Slocum, trajectory, underwater glider, water, wmo</att>
+                            <att name="keywords_vocabulary">GCMD Science Keywords</att>
+                            <att name="Metadata_Conventions">Unidata Dataset Discovery v1.0, COARDS, CF-1.6</att>
+                            <att name="sourceUrl">(local files)</att>
+                            <att name="infoUrl">https://gliders.ioos.us/erddap/</att>
+                            <!-- title=datasetID -->
+                            <att name="title">{deployment.name}</att>
+                            <att name="ioos_dac_checksum">{checksum}</att>
+                            <att name="ioos_dac_completed">{completed}</att>
+                            <att name="gts_ingest">{gts_ingest}</att>
+                        </addAttributes>
+                    </dataset>
                 """)
+                
             for var in variable_order:
                 tree.append(var)
             for identifier, mod_attrs in extra_atts.items():
@@ -724,6 +723,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
             logger.exception("Exception occurred while adding atts to template: {}".format(deployment_dir))
         finally:
             return etree.tostring(tree, encoding=str)
+
 
 def qartod_var_snippets(required_qartod_vars, qartod_var_type):
 
@@ -735,9 +735,7 @@ def qartod_var_snippets(required_qartod_vars, qartod_var_type):
        
         if req_var in qartod_var_type['qartod']:
             continue
-
         else:
-
             flag_atts = """
                     <att name="_FillValue" type="byte">2</att>
                     <att name="dac_comment">QARTOD TESTS NOT RUN</att>
@@ -766,7 +764,7 @@ def qartod_var_snippets(required_qartod_vars, qartod_var_type):
         var_list.append(etree.fromstring(qartod_snip))
 
     return var_list
-
+    
 
 def add_erddap_var_elem(var):
     """

--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -634,7 +634,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
                 'standard_name': 'location_test_quality_flag'
             },
         }
-    
+
     existing_varnames = {'trajectory', 'wmo_id', 'platform', 'instrument_ctd',
                          'profile_id', 'profile_time', 'profile_lat', 'profile_lon',
                          'time', 'depth', 'lat', 'lon',
@@ -643,7 +643,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
 
 
     nc_file = os.path.join(data_root, deployment_dir, latest_file)
-    
+
     with Dataset(nc_file, 'r') as ds:
 
         qartod_var_type = check_for_qartod_vars(ds)
@@ -714,7 +714,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
                         </addAttributes>
                     </dataset>
                 """)
-                
+
             for var in variable_order:
                 tree.append(var)
             for identifier, mod_attrs in extra_atts.items():
@@ -729,10 +729,10 @@ def qartod_var_snippets(required_qartod_vars, qartod_var_type):
 
     var_list = []
     for req_var, template in list(required_qartod_vars.items()):
-        
+
         # If the required QARTOD variable isn't already defined,
         # then supply a set of default attributes.
-       
+
         if req_var in qartod_var_type['qartod']:
             continue
         else:
@@ -747,24 +747,24 @@ def qartod_var_snippets(required_qartod_vars, qartod_var_type):
                     <att name="valid_min" type="byte">1</att>
                     <att name="valid_max" type="byte">9</att>
                     """
-     
+
         qartod_snip = f"""
             <dataVariable>
                 <sourceName>{req_var}</sourceName>
                 <destinationName>{req_var}</destinationName>
                 <dataType>byte</dataType>
-                <addAttributes> 
+                <addAttributes>
                     <att name="long_name">{template['long_name']}</att>
                     <att name="standard_name"> {template['standard_name']} </att>
                     {flag_atts}
                 </addAttributes>
             </dataVariable>
             """
-        
+
         var_list.append(etree.fromstring(qartod_snip))
 
     return var_list
-    
+
 
 def add_erddap_var_elem(var):
     """


### PR DESCRIPTION
This is related to issue #385 and issue #382


Made a few modifications to hard-code the QARTOD variables' long and standard names:

- removed the "qartod_monotonic_pressure_flag" [it is no longer part of the QC tests]
- Changed the required_qartod_vars to a dictionary.
- Updated the qartod_var_snippets() function to utilize the dictionary and add the attributes long_name and standard_name to the default QARTOD variable attributes if the required QARTOD variable isn't already defined.
