### PR TITLE
Email for non completed glider deployments

### DIFF
--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -260,8 +260,7 @@ def notify_incomplete_deployments(username):
     """
 
     user_email = db.users.find_one({"username": username})["email"]
-    send_email(user_email, subject, body)
     msg = Message(subject, recipients=[user_email])
-    msg.body = body
+    msg.html = body
 
     send_email_wrapper(msg)

--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -221,7 +221,7 @@ def notify_incomplete_deployments(username):
         'completed': False,
         'updated': {'$lt': two_weeks_ago},
         'username': username  # Filter by username
-    }).sort({'updated': pymongo.ASCENDING})
+    }).sort('updated', pymongo.ASCENDING)
 
     # Convert the cursor to a list
     deployments = list(incomplete_deployments)

--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -228,7 +228,6 @@ def notify_incomplete_deployments(username):
 
     # Check if there are any deployments to notify about
     if not deployments:
-        print(f"No incomplete deployments found for user: {username}")
         return
 
     # Prepare email content
@@ -238,7 +237,7 @@ def notify_incomplete_deployments(username):
     body = f"""
     <html>
     <body>
-        <p>You have the following incomplete deployments that were last updated more than two weeks ago:</p>
+        <p>User {username} has the following incomplete deployments that were last updated more than two weeks ago:</p>
         <table border="1" style="border-collapse: collapse;">
             <tr>
                 <th>Deployment Name</th>
@@ -260,10 +259,9 @@ def notify_incomplete_deployments(username):
     </html>
     """
 
-    # Send email (you may want to fetch the user's email address based on the username)
-    user_email = db.users.find_one({"username": username})  # Replace with actual email retrieval logic
+    user_email = db.users.find_one({"username": username})["email"]
     send_email(user_email, subject, body)
-    msg = Message(subject, recipients=recipients)
+    msg = Message(subject, recipients=[user_email])
     msg.body = body
 
     send_email_wrapper(msg)

--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -237,7 +237,8 @@ def notify_incomplete_deployments(username):
     body = f"""
     <html>
     <body>
-        <p>User {username} has the following incomplete deployments that were last updated more than two weeks ago:</p>
+        <p>User {username} has the following incomplete glider deployment(s) on the IOOS Glider DAC that were last updated more than two weeks ago.
+           Please mark the following deployment(s) as complete if the associated deployments have finished.</p>
         <table border="1" style="border-collapse: collapse;">
             <tr>
                 <th>Deployment Name</th>

--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -2,10 +2,11 @@ import os
 from flask_mail import Message
 from flask import render_template
 from glider_dac import app, mail, db
-from datetime import datetime
+from datetime import datetime, timedelta
 from compliance_checker.suite import CheckSuite
 from compliance_checker.runner import ComplianceChecker
 from urllib.parse import urljoin
+import pymongo
 import tempfile
 import glob
 import sys
@@ -210,3 +211,59 @@ def process_deployment(dep):
     # Set fields.  Don't use upsert as deployment ought to exist prior to write.
     db.deployments.update({"_id": dep["_id"]}, {"$set": update_fields})
     return final_message.startswith("All files passed"), final_message
+
+def notify_incomplete_deployments(username):
+    # Calculate the date two weeks ago
+    two_weeks_ago = datetime.now() - timedelta(weeks=2)
+
+    # Query for deployments that are not completed, last updated more than two weeks ago, and match the username
+    incomplete_deployments = db.deployments.find({
+        'completed': False,
+        'updated': {'$lt': two_weeks_ago},
+        'username': username  # Filter by username
+    }).sort({'updated': pymongo.ASCENDING})
+
+    # Convert the cursor to a list
+    deployments = list(incomplete_deployments)
+
+    # Check if there are any deployments to notify about
+    if not deployments:
+        print(f"No incomplete deployments found for user: {username}")
+        return
+
+    # Prepare email content
+    subject = f"Reminder: Incomplete Deployments for {username}"
+
+    # Start building the HTML table
+    body = f"""
+    <html>
+    <body>
+        <p>You have the following incomplete deployments that were last updated more than two weeks ago:</p>
+        <table border="1" style="border-collapse: collapse;">
+            <tr>
+                <th>Deployment Name</th>
+                <th>Last Updated</th>
+            </tr>
+    """
+
+    for deployment in deployments:
+        body += f"""
+            <tr>
+                <td>{deployment['name']}</td>
+                <td>{deployment['updated'].strftime('%Y-%m-%d %H:%M:%S')}</td>
+            </tr>
+        """
+
+    body += """
+        </table>
+    </body>
+    </html>
+    """
+
+    # Send email (you may want to fetch the user's email address based on the username)
+    user_email = db.users.find_one({"username": username})  # Replace with actual email retrieval logic
+    send_email(user_email, subject, body)
+    msg = Message(subject, recipients=recipients)
+    msg.body = body
+
+    send_email_wrapper(msg)


### PR DESCRIPTION
Adds an email template to notify users/providers of deployments that are not marked as completed and have not seen updates for over two weeks.