### PR TITLE
Pass compliance checking to scheduled jobs

### DIFF
--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -193,8 +193,8 @@ def process_deployment(dep):
         final_message = "All files passed compliance check on glider deployment {}".format(dep['name'])
     else:
         error_list = [err_msg for err_severity in ("high_priorities",
-            "medium_priorities", "low_priorities") for err_section in
-            errs[err_severity] for err_msg in err_section["msgs"]]
+                      "medium_priorities", "low_priorities") for err_section in
+                      errs[err_severity] for err_msg in err_section["msgs"]]
         update_fields["compliance_check_report"] = errs
 
         for err in errs["high_priorities"]:

--- a/glider_dac/worker.py
+++ b/glider_dac/worker.py
@@ -10,7 +10,7 @@ listen = ['default']
 def main():
     with Connection(redis_connection):
         worker = Worker(list(map(Queue, listen)))
-        worker.work()
+        worker.work(with_scheduler=True)
 
 if __name__ == '__main__':
     main()

--- a/glider_qc/glider_qc.py
+++ b/glider_qc/glider_qc.py
@@ -604,7 +604,6 @@ def check_needs_qc(nc_path):
         if os.getxattr(nc_path, "user.qc_run"):
             return False
     except OSError:
-        log.exception(f"Exception occurred trying to get xattr at {nc_path}:")
         pass
     with Dataset(nc_path, 'r') as nc:
         qc = GliderQC(nc, None)


### PR DESCRIPTION
Moves compliance checks on deployments to jobs scheduled half an hour in the future.  If, on further invocations of checking if the compliance check passed, if it is found that there is already a job scheduled in the future for a particular deployment, the compliance check is not scheduled again.  This cuts down on duplication of jobs and the associated processing overhead due to many detected file events while also allowing for conditions such as deployment data resubmission to be handled.