### PR TITLE
modified apply_qc() to use PandasStore

### DIFF
--- a/glider_qc/glider_qc.py
+++ b/glider_qc/glider_qc.py
@@ -440,18 +440,18 @@ class GliderQC(object):
             store = PandasStore(results)
         except Exception as e:
             log.error(f"Error collecting QC results for {varname}: {e}")
-            return []    
+            return []
 
-        # Step 5: Compute any aggregations 
+        # Step 5: Compute any aggregations
         try:
             store.compute_aggregate(name='rollup_qc')  # Appends to the results internally
         except Exception as e:
             log.error(f"Error computing any aggregations for {varname}: {e}")
-            return []            
-        
+            return []
+
         # Step 6: Write only the test results to the store
         results_store = store.save(write_data=False, write_axes=False)
-        
+
         return results_store
 
     def check_geophysical_variables(self, var_name):
@@ -853,7 +853,7 @@ def check_needs_qc(nc_path):
 
         # Set the extended attribute
         #os.setxattr(nc_path, "user.qc_run", iso_date_bytes)
-    
+
     except OSError:
         log.exception(f"Exception occurred trying to set xattr on already QCed file at {nc_path}:")
     return False

--- a/tests/test_glider_qc.py
+++ b/tests/test_glider_qc.py
@@ -78,23 +78,21 @@ class TestGliderQC(TestCase):
 
         results_raw = qc.apply_qc(df, 'temperature', qc_config)
 
-        results_dict = {r.test: r.results for r in results_raw if r.stream_id == 'temperature'}
+        np.testing.assert_equal(
+            np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
+            results_raw['temperature_qartod_gross_range_test'][:])
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_dict['gross_range_test'][:])
+            results_raw['temperature_qartod_flat_line_test'])
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_dict['flat_line_test'])
-
-        np.testing.assert_equal(
-            np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_dict['rate_of_change_test'])
+            results_raw['temperature_qartod_rate_of_change_test'])
 
         np.testing.assert_equal(
             np.array([2, 1, 1, 1, 1, 1, 1, 2], dtype=np.int8),
-            results_dict['spike_test'])
+            results_raw['temperature_qartod_spike_test'])
 
     def test_units_qc(self):
         fd, fake_file = tempfile.mkstemp()
@@ -131,9 +129,7 @@ class TestGliderQC(TestCase):
         df = pd.DataFrame({"time": times[:].astype('datetime64[s]'), "temp": values,},)
         results_raw = qc.apply_qc(df, 'temp', qc_config)
 
-        results_dict = {r.test: r.results for r in results_raw if r.stream_id == 'temp'}
-
-        np.testing.assert_equal(results_dict['flat_line_test'][:], np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
+        np.testing.assert_equal(results_raw['temperature_qartod_flat_line_test'][:], np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
 
     def test_normalize_variable(self):
         values = np.array([32.0, 65.0, 100.0])

--- a/tests/test_glider_qc.py
+++ b/tests/test_glider_qc.py
@@ -80,19 +80,19 @@ class TestGliderQC(TestCase):
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temp_qartod_gross_range_test'][:])
+            np.array(results_raw['temperature_qartod_gross_range_test'].values))
                          
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temp_qartod_flat_line_test'])
+            np.array(results_raw['temperature_qartod_flat_line_test'].values))
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temp_qartod_rate_of_change_test'])
+            np.array(results_raw['temperature_qartod_rate_of_change_test'].values))
 
         np.testing.assert_equal(
             np.array([2, 1, 1, 1, 1, 1, 1, 2], dtype=np.int8),
-            results_raw['temp_qartod_spike_test'])
+            np.array(results_raw['temperature_qartod_spike_test'].values))
 
     def test_units_qc(self):
         fd, fake_file = tempfile.mkstemp()
@@ -129,7 +129,7 @@ class TestGliderQC(TestCase):
         df = pd.DataFrame({"time": times[:].astype('datetime64[s]'), "temp": values,},)
         results_raw = qc.apply_qc(df, 'temp', qc_config)
 
-        np.testing.assert_equal(results_raw['temp_qartod_flat_line_test'][:], np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
+        np.testing.assert_equal(np.array(results_raw['temperature_qartod_flat_line_test'].values), np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
 
     def test_normalize_variable(self):
         values = np.array([32.0, 65.0, 100.0])

--- a/tests/test_glider_qc.py
+++ b/tests/test_glider_qc.py
@@ -129,7 +129,7 @@ class TestGliderQC(TestCase):
         df = pd.DataFrame({"time": times[:].astype('datetime64[s]'), "temp": values,},)
         results_raw = qc.apply_qc(df, 'temp', qc_config)
 
-        np.testing.assert_equal(np.array(results_raw['temperature_qartod_flat_line_test'].values), np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
+        np.testing.assert_equal(np.array(results_raw['temp_qartod_flat_line_test'].values), np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
 
     def test_normalize_variable(self):
         values = np.array([32.0, 65.0, 100.0])

--- a/tests/test_glider_qc.py
+++ b/tests/test_glider_qc.py
@@ -81,7 +81,7 @@ class TestGliderQC(TestCase):
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
             np.array(results_raw['temperature_qartod_gross_range_test'].values))
-                         
+
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
             np.array(results_raw['temperature_qartod_flat_line_test'].values))

--- a/tests/test_glider_qc.py
+++ b/tests/test_glider_qc.py
@@ -80,19 +80,19 @@ class TestGliderQC(TestCase):
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temperature_qartod_gross_range_test'][:])
+            results_raw['temp_qartod_gross_range_test'][:])
+                         
+        np.testing.assert_equal(
+            np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
+            results_raw['temp_qartod_flat_line_test'])
 
         np.testing.assert_equal(
             np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temperature_qartod_flat_line_test'])
-
-        np.testing.assert_equal(
-            np.array([1, 1, 1, 1, 1, 1, 1, 1], dtype=np.int8),
-            results_raw['temperature_qartod_rate_of_change_test'])
+            results_raw['temp_qartod_rate_of_change_test'])
 
         np.testing.assert_equal(
             np.array([2, 1, 1, 1, 1, 1, 1, 2], dtype=np.int8),
-            results_raw['temperature_qartod_spike_test'])
+            results_raw['temp_qartod_spike_test'])
 
     def test_units_qc(self):
         fd, fake_file = tempfile.mkstemp()
@@ -129,7 +129,7 @@ class TestGliderQC(TestCase):
         df = pd.DataFrame({"time": times[:].astype('datetime64[s]'), "temp": values,},)
         results_raw = qc.apply_qc(df, 'temp', qc_config)
 
-        np.testing.assert_equal(results_raw['temperature_qartod_flat_line_test'][:], np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
+        np.testing.assert_equal(results_raw['temp_qartod_flat_line_test'][:], np.array([1, 1, 1, 3, 4, 9, 4, 4, 1, 9], dtype=np.int8))
 
     def test_normalize_variable(self):
         values = np.array([32.0, 65.0, 100.0])


### PR DESCRIPTION
Upgrading to ioos-qc version 2.2.0 caused a TypeError: 'ABCMeta' object is not subscriptable when running glider_qc_tests.py. The issue traced back to the aggregate method from the ioos-qc package. To resolve this, I modified glider_qc.py to use the PandasStore method for creating the aggregated flags.

Note: I have also added a TODO comments to set the extended file attribute as the current date-time.