### PR TITLE
Feature/docker mac build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,61 @@
-FROM python:3.12
+#FROM python:3.12
+
+#ARG glider_gid_uid=1000
+#COPY . /glider-dac
+#ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits
+#RUN apt-get update && \
+#    apt-get -y install libxml2-dev netcdf-bin rsync && \
+#    cd /usr/local/src && pip install -U pip && \
+#    pip install --no-cache -r /glider-dac/requirements.txt && \
+#    apt-get -y remove libxml2-dev && rm -rf /var/lib/apt/lists/*
+# TODO: move logs elsewhere
+#VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.13/site-packages/compliance_checker/data
+#WORKDIR /glider-dac
+#RUN mkdir -p /data/submission /data/data/priv_erddap /data/data/pub_erddap \
+#             /erddapData/flag /erddapData/hardFlag  \
+#             /data/catalog/priv_erddap
+#ENV PYTHONPATH="${PYTHONPATH:-}:/glider-dac"
+#ENV FLASK_APP=glider_dac:create_app
+#
+#EXPOSE 5000
+#CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "glider_dac:create_app()"]
+
+
+FROM python:3.11
 
 ARG glider_gid_uid=1000
 COPY . /glider-dac
-ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits
+
+ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2.xml
+
+RUN echo "Python version: $(python --version)" && pip debug --verbose
+
+# Install system dependencies
 RUN apt-get update && \
-    apt-get -y install libxml2-dev netcdf-bin rsync && \
-    cd /usr/local/src && pip install -U pip && \
-    pip install --no-cache -r /glider-dac/requirements.txt && \
-    apt-get -y remove libxml2-dev && rm -rf /var/lib/apt/lists/*
-# TODO: move logs elsewhere
-VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.13/site-packages/compliance_checker/data
+    apt-get -y install libxml2-dev libudunits2-dev netcdf-bin rsync && \
+    pip install -U pip
+
+# Install cf-units FIRST (valid version, with source fallback)
+RUN pip install cf-units==3.2.0
+
+# Now install the rest of your app requirements
+RUN pip install --no-cache -r /glider-dac/requirements.txt
+
+# Clean up
+RUN apt-get -y remove libxml2-dev libudunits2-dev && rm -rf /var/lib/apt/lists/*
+
+# Volume and working directories
+VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.11/site-packages/compliance_checker/data
+
 WORKDIR /glider-dac
+
 RUN mkdir -p /data/submission /data/data/priv_erddap /data/data/pub_erddap \
              /erddapData/flag /erddapData/hardFlag  \
              /data/catalog/priv_erddap
-ENV PYTHONPATH="${PYTHONPATH:-}:/glider-dac"
+
+ENV PYTHONPATH="/glider-dac"
 ENV FLASK_APP=glider_dac:create_app
 
 EXPOSE 5000
+
 CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "glider_dac:create_app()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM python:3.11
-
-ARG glider_gid_uid=1000
+ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2.xml \
+    PYTHONPATH="/glider-dac" FLASK_APP=glider_dac:create_app
 COPY . /glider-dac
 
-ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/
-
 # Install system dependencies
+# Install cf-units FIRST (valid version, with source fallback)
+# Then install the remainder of the app requirements
 RUN apt-get update && \
     apt-get -y install libxml2-dev libudunits2-dev netcdf-bin rsync && \
-    pip install -U pip && \
-    pip install cf-units==3.2.0 && \
+    pip install --no-cache -U pip && \
+    pip install --no-cache cf-units==3.2.0 && \
     pip install --no-cache -r /glider-dac/requirements.txt && \
     apt-get -y remove libxml2-dev libudunits2-dev && rm -rf /var/lib/apt/lists/*
 
@@ -21,9 +21,6 @@ WORKDIR /glider-dac
 RUN mkdir -p /data/submission /data/data/priv_erddap /data/data/pub_erddap \
              /erddapData/flag /erddapData/hardFlag  \
              /data/catalog/priv_erddap
-
-ENV PYTHONPATH="/glider-dac"
-ENV FLASK_APP=glider_dac:create_app
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,17 @@
-#FROM python:3.12
-
-#ARG glider_gid_uid=1000
-#COPY . /glider-dac
-#ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits
-#RUN apt-get update && \
-#    apt-get -y install libxml2-dev netcdf-bin rsync && \
-#    cd /usr/local/src && pip install -U pip && \
-#    pip install --no-cache -r /glider-dac/requirements.txt && \
-#    apt-get -y remove libxml2-dev && rm -rf /var/lib/apt/lists/*
-# TODO: move logs elsewhere
-#VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.13/site-packages/compliance_checker/data
-#WORKDIR /glider-dac
-#RUN mkdir -p /data/submission /data/data/priv_erddap /data/data/pub_erddap \
-#             /erddapData/flag /erddapData/hardFlag  \
-#             /data/catalog/priv_erddap
-#ENV PYTHONPATH="${PYTHONPATH:-}:/glider-dac"
-#ENV FLASK_APP=glider_dac:create_app
-#
-#EXPOSE 5000
-#CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "glider_dac:create_app()"]
-
-
 FROM python:3.11
 
 ARG glider_gid_uid=1000
 COPY . /glider-dac
 
-ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2.xml
-
-RUN echo "Python version: $(python --version)" && pip debug --verbose
+ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/
 
 # Install system dependencies
 RUN apt-get update && \
     apt-get -y install libxml2-dev libudunits2-dev netcdf-bin rsync && \
-    pip install -U pip
-
-# Install cf-units FIRST (valid version, with source fallback)
-RUN pip install cf-units==3.2.0
-
-# Now install the rest of your app requirements
-RUN pip install --no-cache -r /glider-dac/requirements.txt
-
-# Clean up
-RUN apt-get -y remove libxml2-dev libudunits2-dev && rm -rf /var/lib/apt/lists/*
+    pip install -U pip && \
+    pip install cf-units==3.2.0 && \
+    pip install --no-cache -r /glider-dac/requirements.txt && \
+    apt-get -y remove libxml2-dev libudunits2-dev && rm -rf /var/lib/apt/lists/*
 
 # Volume and working directories
 VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.11/site-packages/compliance_checker/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     build: .
     ports:
-      - 5000:5000
+      - 5050:5000
     volumes:
       #- ./config.local.yml:/glider-dac/config.local.yml
       - log_volume:/glider-dac/logs
@@ -71,7 +71,8 @@ services:
   # TODO: THREDDS and ERDDAP will need volume configurations
   thredds:
     container_name: thredds
-    image: unidata/thredds-docker:5.4
+    image: unidata/thredds-docker:5.6
+    platform: linux/amd64
     ports:
       - 8082:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     build: .
     ports:
-      - 5050:5000
+      - 5000:5000
     volumes:
       #- ./config.local.yml:/glider-dac/config.local.yml
       - log_volume:/glider-dac/logs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.10.11
 aiofiles==24.1.0
 async-timeout<5.0
 awscli
-#asyncio==3.4.3
+asyncio==3.4.3
 Flask<2.4
 Flask-Login>=0.5.0
 gunicorn>=20.1.0
@@ -22,8 +22,7 @@ sh==1.09
 passlib>=1.7.4
 requests>=2.20.1
 simplekv
-#Werkzeug>=3.0.6
-Werkzeug==2.2.3
+Werkzeug>=3.0.6
 thredds_crawler>=1.5.4
 Flask-Session
 pyyaml>=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ mysqlclient
 geojson
 marshmallow
 marshmallow-sqlalchemy
-numpy<2.0
 watchdog>=0.9.0
 lxml==5.3.1
 Flask-Mail==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.10.11
 aiofiles==24.1.0
 async-timeout<5.0
 awscli
-asyncio==3.4.3
+#asyncio==3.4.3
 Flask<2.4
 Flask-Login>=0.5.0
 gunicorn>=20.1.0
@@ -22,7 +22,8 @@ sh==1.09
 passlib>=1.7.4
 requests>=2.20.1
 simplekv
-Werkzeug>=3.0.6
+#Werkzeug>=3.0.6
+Werkzeug==2.2.3
 thredds_crawler>=1.5.4
 Flask-Session
 pyyaml>=6.0
@@ -31,7 +32,8 @@ redis
 rq-dashboard==0.3.4
 ioos-qc==2.2.0
 netCDF4>=1.5.8
-cf-units>=2.1.5
+#cf-units>=2.1.5
+cf-units==3.2.0
 # newer functions
 cftime==1.6.4.post1
 flask-cors==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ mysqlclient
 geojson
 marshmallow
 marshmallow-sqlalchemy
+numpy<2.0
 watchdog>=0.9.0
 lxml==5.3.1
 Flask-Mail==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ mysqlclient
 geojson
 marshmallow
 marshmallow-sqlalchemy
+numpy<2.0
 watchdog>=0.9.0
 lxml==5.3.1
 Flask-Mail==0.9.0
@@ -31,7 +32,6 @@ redis
 rq-dashboard==0.3.4
 ioos-qc==2.2.0
 netCDF4>=1.5.8
-#cf-units>=2.1.5
 cf-units==3.2.0
 # newer functions
 cftime==1.6.4.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.10.11
 aiofiles==24.1.0
 async-timeout<5.0
 awscli
-asyncio==3.4.3
 Flask<2.4
 Flask-Login>=0.5.0
 gunicorn>=20.1.0


### PR DESCRIPTION
made changes to Dockerfile, requirements.txt and docker-compose.yml to work with arm64 (an ARM-based Mac, Apple Silicon) 

the main changes are:
- downgrade to python3.11
- modified packages to work with python3.11
- specify the platform for the thredds image (platform: linux/amd64)
- changes the image tag for THREDDS to unidata/thredds-docker:5.6
- changed the glider-dac-providers-app port to an open port on my Mac