### PR TITLE
Update glider_qc.py

### DIFF
--- a/glider_qc/glider_qc.py
+++ b/glider_qc/glider_qc.py
@@ -68,8 +68,6 @@ class GliderQC(object):
         valid_variables = []
         ancillary_variables = getattr(ncvariable, 'ancillary_variables', None)
         if ancillary_variables is None:
-            # create an ancillary variable
-            ncvariable.ancillary_variables = ''
             log.info("Missing ancillary_variables for %s added", ncvariable.name)
             return []
 


### PR DESCRIPTION
removed ncvariable.ancillary_variables = '' line from the the qc setup in the find_qc_flags() function to handle the exception raised in the watchdog script