### PR TITLE
Use proper component for NAVOCEANO date comparison

### DIFF
--- a/glider_dac_watchdog.py
+++ b/glider_dac_watchdog.py
@@ -62,7 +62,7 @@ class HandleDeploymentDB(FileSystemEventHandler):
                 navo_deployment_directory = None
                 for maybe_dir in possible_existing_dirs:
                     if os.path.isdir(maybe_dir):
-                        dir_date_part = maybe_dir.rsplit("-", 1)[0]
+                        dir_date_part = maybe_dir.rsplit("-", 1)[-1]
                         # get most recent matching directory
                         if date_str >= dir_date_part:
                             navo_deployment_directory = maybe_dir


### PR DESCRIPTION
Uses appropriate date part of NAVOCEANO deployment directory names for comparison against deployment files to determine the appropriate directory to place files.