### PR TITLE
NAVOCEANO backfill data script by year

### DIFF
--- a/scripts/create_navoceano_symlinks.bash
+++ b/scripts/create_navoceano_symlinks.bash
@@ -8,7 +8,13 @@ cd "$navo_dir" || exit
 
 for dest_dir in ng*; do
     glider_name="${dest_dir%%-*}"
-    for source_file in "hurricanes-20230601T0000/$glider_name"*.nc; do
+    # DANGER: this assumes navoceano only makes only deployment per glider with
+    # a given callsign per year.  Will create duplicates in folders if this
+    # assumption is not met
+    # Also will not handle year crossing for deployments which go to the new year.
+    year="${dest_dir##*-}"
+    year="${year:0:4}"
+    for source_file in "hurricanes-20230601T0000/${glider_name}_${year}"*.nc; do
         no_dir="${source_file#*/}"
         no_z="${no_dir/%Z.nc/.nc}"
         symlink_dest="$dest_dir/${no_z/_/-}"


### PR DESCRIPTION
Backfills NAVOCEANO deployments based upon glider name and deployment year, avoiding issues with filling to wrong deployment and duplicates. Operates under the assumption that each glider is deployed once per year and will require updates for multiple deployments per year.