### PR TITLE
fix: close tempfile fd and unlink after compliance check

### DIFF
--- a/glider_dac/glider_emails.py
+++ b/glider_dac/glider_emails.py
@@ -175,17 +175,22 @@ def process_deployment(dep):
     # TODO: would be better if we didn't have to write to a temp file
     outhandle, outfile = tempfile.mkstemp()
     try:
-        failures, _ = ComplianceChecker.run_checker(ds_loc=url_path,
-                                      checker_names=['gliderdac'], verbose=True,
-                                      criteria='lenient', output_format='json',
-                                      output_filename=outfile)
-        with open(outfile, 'r') as f:
-            errs = json.load(f)["gliderdac"]
+        os.close(outhandle)  # close raw fd immediately; checker writes by path
+        try:
+            failures, _ = ComplianceChecker.run_checker(ds_loc=url_path,
+                                          checker_names=['gliderdac'], verbose=True,
+                                          criteria='lenient', output_format='json',
+                                          output_filename=outfile)
+            with open(outfile, 'r') as f:
+                errs = json.load(f)["gliderdac"]
 
-        compliance_passed = errs['scored_points'] == errs['possible_points']
-    except OSError:
-        root_logger.exception("Potentially failed to open netCDF file:")
-        compliance_passed = False
+            compliance_passed = errs['scored_points'] == errs['possible_points']
+        except OSError:
+            root_logger.exception("Potentially failed to open netCDF file:")
+            compliance_passed = False
+    finally:
+        if os.path.exists(outfile):
+            os.unlink(outfile)
 
     update_fields = {"compliance_check_passed": compliance_passed}
     standard_name_errs = []


### PR DESCRIPTION
## **Summary**

This change fixes a critical resource leak in `glider_dac/glider_emails.py` within the `process_deployment()` workflow.

The function uses `tempfile.mkstemp()` to generate a temporary file for `ComplianceChecker.run_checker()`. However, the returned **file descriptor (`outhandle`) and temporary file (`outfile`) were never cleaned up**, leading to:

* File descriptor leaks (OS-level)
* Accumulation of temp files in `/tmp`
* Gradual exhaustion of system resources in long-running RQ workers

### Problematic pattern:

```python
outhandle, outfile = tempfile.mkstemp()

ComplianceChecker.run_checker(..., output_filename=outfile)

with open(outfile, 'r') as f:
    errs = json.load(f)["gliderdac"]
```

No `os.close()` or `os.unlink()` is performed, meaning every job permanently leaks resources.

Since the RQ worker is a **long-lived process**, this results in **linear growth of open file descriptors**, eventually causing:

```
OSError: [Errno 24] Too many open files
```

---

## **Fix**

The fix ensures proper lifecycle management of both the file descriptor and the temporary file.

### Key changes:

1. **Immediately close the raw file descriptor** returned by `mkstemp()`
2. **Ensure file deletion via `finally` block**, regardless of success or failure
3. Preserve existing logic and error handling (minimal, safe change)

### Fixed pattern:

```python
outhandle, outfile = tempfile.mkstemp()

os.close(outhandle)  # close fd immediately

try:
    failures, _ = ComplianceChecker.run_checker(..., output_filename=outfile)

    with open(outfile, 'r') as f:
        errs = json.load(f)["gliderdac"]

    compliance_passed = errs['scored_points'] == errs['possible_points']

except OSError:
    root_logger.exception("Potentially failed to open netCDF file:")
    compliance_passed = False

finally:
    if os.path.exists(outfile):
        os.unlink(outfile)
```

### Why this works:

* `ComplianceChecker` operates on the **file path**, not the original descriptor → safe to close immediately
* `finally` guarantees cleanup across all execution paths
* Prevents both **FD leaks** and **disk accumulation**

---

## **Verification**

The fix was validated using realistic worker behavior:

### Reproduction (before fix):

* Ran multiple `process_deployment()` jobs via RQ worker
* Observed:

  * `lsof -p <pid>` → steadily increasing file descriptors
  * `/tmp` → growing temp files
  * Eventually → `EMFILE` errors and worker instability

### After fix:

* Repeated the same workload
* Observed:

  * **Stable file descriptor count**
  * **No temp file accumulation**
  * No `OSError: Too many open files`
  * Worker remains stable across long runs

### Additional validation:

* Confirmed compliance checker still reads/writes correctly via file path
* Verified no regression in email/compliance flow

---

## **Impact**

* Eliminates a **production-critical resource leak**
* Prevents **RQ worker crashes and cascading failures**
* Ensures **long-term stability** under continuous job processing
* Removes need for manual worker restarts


This is a minimal, targeted fix that resolves a high-severity issue without altering existing behavior.
