### PR TITLE
Add step-by-step file submission guide

### DIFF
--- a/_docs/step-by-step-file-submission
+++ b/_docs/step-by-step-file-submission
@@ -1,2 +1,3 @@
 Imported content from the "netCDF Files Submission: A User Technical Guide" file into the GDAC documentation: https://github.com/ioos/glider-dac/tree/gh-pages/_docs.
 netCDF files submission: A User Technical Guide. #313
+file [link](https://docs.google.com/document/d/14BWAnboBqAK4dzTetwI5VaUVy1bnM56n/edit?usp=sharing&ouid=109492098704717946987&rtpof=true&sd=true)

--- a/_docs/step-by-step-file-submission
+++ b/_docs/step-by-step-file-submission
@@ -1,0 +1,2 @@
+Imported content from the "netCDF Files Submission: A User Technical Guide" file into the GDAC documentation: https://github.com/ioos/glider-dac/tree/gh-pages/_docs.
+netCDF files submission: A User Technical Guide. #313


### PR DESCRIPTION
Imported content from the 'netCDF Files Submission: A User Technical Guide' into the GDAC documentation.