### PR TITLE
Use uv for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,32 +4,28 @@
 # and VOLUME instruction corresponding to Compliance
 # Checker cache to avoid collision and using wrong
 # path for volume
-ARG PYTHON_VERSION_SHORT=3.12
-FROM python:$PYTHON_VERSION_SHORT
+FROM python:3.12
 ENV UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2.xml \
-    PYTHONPATH="/glider-dac" FLASK_APP=glider_dac:create_app
-ARG PYTHON_VERSION_SHORT=3.12
+  PYTHONPATH="/glider-dac" FLASK_APP=glider_dac:create_app
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /bin/
 COPY . /glider-dac
-
-
 
 # Install system dependencies
 # Install cf-units FIRST (valid version, with source fallback)
 # Then install the remainder of the app requirements
 RUN apt-get update && \
-    apt-get -y install rsync libudunits2-dev && \
-    pip install --no-cache -U pip && \
-    pip install --no-cache -r /glider-dac/requirements.txt && \
-    rm -rf /var/lib/apt/lists/*
+  apt-get -y install rsync libudunits2-dev curl && \
+  uv pip install --system -r /glider-dac/requirements.txt && \
+  rm -rf /var/lib/apt/lists/*
 
 # Volume and working directories
-VOLUME /glider-dac/logs/ /data /usr/local/lib/python$PYTHON_VERSION_SHORT/site-packages/compliance_checker/data
+VOLUME /glider-dac/logs/ /data /usr/local/lib/python3.12/site-packages/compliance_checker/data
 
 WORKDIR /glider-dac
 
 RUN mkdir -p /data/submission /data/data/priv_erddap /data/data/pub_erddap \
-             /erddapData/flag /erddapData/hardFlag  \
-             /data/catalog/priv_erddap
+  /erddapData/flag /erddapData/hardFlag  \
+  /data/catalog/priv_erddap
 
 EXPOSE 5000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ cftime==1.6.4.post1
 flask-cors==6.0.2
 compliance-checker>=5.0.0
 cc-plugin-glider>=2.1.0
--e git+https://github.com/flasgger/flasgger.git@master#egg=flasgger
+git+https://github.com/flasgger/flasgger.git@bb1a86b2d#egg=flasgger
 multidict
 influxdb>=5.3.1
 quantities==0.16.4


### PR DESCRIPTION
Uses uv to speed up the Docker build.
Also eliminates PYTHON_VERSION_SHORT Docker build argument.