### PR TITLE
Fix dac_qc_comment attribute to aggregated dataset

### DIFF
--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -701,6 +701,7 @@ def build_erddap_catalog_chunk(data_root, deployment):
                             <att name="ioos_dac_checksum">{checksum}</att>
                             <att name="ioos_dac_completed">{completed}</att>
                             <att name="gts_ingest">{gts_ingest}</att>
+                            <att name="dac_qc_comment">For detailed quality control comments specific to each deployment, please refer to the dac_qc_comment attribute in the individual deployment files.</att>
                         </addAttributes>
                     </dataset>
                 """)


### PR DESCRIPTION
added <att name="dac_qc_comment">...</att> in the <addAttributes> block in ERDDAP XML chunk to overwrite the value from the NetCDF files in the ERDDAP aggregated dataset.