### PR TITLE
fix all GHA hash and repos

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -28,7 +28,7 @@ jobs:
 
     - name: Check links
       if: steps.check_files.outputs.files_exists == 'true'
-      uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31  # v1.0.17
+      uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  # v1.1.12
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/sync_theme.yml
+++ b/.github/workflows/sync_theme.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout repo
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: gh-pages
         fetch-depth: 0


### PR DESCRIPTION
No idea why the hash and version got disconnect for the checkout action. Taking this opportunity to also fix the markdown link check Action.