### PR TITLE
Use dependabot to update pre-commit CIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,12 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Bot"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     - id: shellcheck
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
 
@@ -34,6 +34,5 @@ ci:
         for more information, see https://pre-commit.ci
     autofix_prs: false
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: monthly
     skip: []
     submodules: false


### PR DESCRIPTION
Updates via dependabot will be consistent with the same policies we use for GHA.