### PR TITLE
not overwriting the variable attribute ioos_category

### DIFF
--- a/glider_dac/tests/test_glider_xml.py
+++ b/glider_dac/tests/test_glider_xml.py
@@ -7,10 +7,16 @@ from lxml import etree
 
 
 class DummyVar:
-    def __init__(self, name, dtype):
+    def __init__(self, name, dtype, attrs=None):
         self.name = name
         self.dtype = dtype
+        self._attrs = attrs or {}
 
+    def ncattrs(self):
+        return list(self._attrs.keys())
+
+    def getncattr(self, key):
+        return self._attrs[key]
 
 class DummyDtype:
     def __init__(self, type_):

--- a/scripts/build_erddap_catalog.py
+++ b/scripts/build_erddap_catalog.py
@@ -769,7 +769,7 @@ def qartod_var_snippets(required_qartod_vars, qartod_var_type):
         else:
             flag_atts = """
                     <att name="_FillValue" type="byte">-128</att>
-                    <att name="dac_comment">QARTOD TESTS NOT RUN</att>
+                    <att name="dac_comment">QARTOD TEST NOT RUN</att>
                     <att name="flag_values" type="byteList">1 2 3 4 9</att>
                     <att name="flag_meanings">PASS NOT_EVALUATED SUSPECT FAIL MISSING</att>
                     <att name="ioos_category">Quality</att>
@@ -818,8 +818,7 @@ def add_erddap_var_elem(var):
         data_type.text = erddap_mapping_dict[var.dtype.type]
     add_atts = etree.SubElement(dvar_elem, "addAttributes")
     ioos_category = etree.SubElement(add_atts, "att", name="ioos_category")
-    ioos_category.text = "Other"
-
+    ioos_category.text = var.getncattr("ioos_category") if "ioos_category" in var.ncattrs() else "Other"
     return dvar_elem
 
 


### PR DESCRIPTION
added fix to the function add_erddap_var_elem(var) so ioos_category is not overwritten if pre-defined in the variable's attributes. 

change:
ioos_category.text = "Other"
to:
ioos_category.text = var.getncattr("ioos_category") if "ioos_category" in var.ncattrs() else "Other"